### PR TITLE
`layers` use `chunks` and `sparse_chunks` API for `zarr`

### DIFF
--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Callable, Type, TypeVar, Union
 from warnings import warn
+from copy import deepcopy
 
 import numpy as np
 from scipy import sparse
@@ -59,7 +60,7 @@ def write_zarr(
     write_attribute(f, "varm", adata.varm, dataset_kwargs)
     write_attribute(f, "obsp", adata.obsp, dataset_kwargs)
     write_attribute(f, "varp", adata.varp, dataset_kwargs)
-    write_attribute(f, "layers", adata.layers, dataset_kwargs)
+    write_attribute(f, "layers", adata.layers, dict(sparse_chunks=sparse_chunks, chunks=chunks, **dataset_kwargs))
     write_attribute(f, "uns", adata.uns, dataset_kwargs)
     write_attribute(f, "raw", adata.raw, dataset_kwargs)
 
@@ -83,7 +84,20 @@ def write_mapping(f, key, value: Mapping, dataset_kwargs=MappingProxyType({})):
                 "string keys is recommended.",
                 WriteWarning,
             )
-        write_attribute(f, f"{key}/{sub_k}", sub_v, dataset_kwargs)
+        is_sparse = isinstance(sub_v, sparse.spmatrix)
+        new_dataset_kwargs_dict = deepcopy(dataset_kwargs.copy())
+        if 'chunks' in dataset_kwargs:
+            if dataset_kwargs['chunks'] is not None and not is_sparse:
+                if 'chunks' in dataset_kwargs:
+                    del new_dataset_kwargs_dict['sparse_chunks']
+                new_dataset_kwargs_dict = dict(chunks=new_dataset_kwargs_dict['chunks'], **new_dataset_kwargs_dict)
+        elif 'sparse_chunks' in dataset_kwargs:
+            if dataset_kwargs['sparse_chunks'] is not None and is_sparse:
+                if 'sparse_chunks' in dataset_kwargs:
+                    del new_dataset_kwargs_dict['chunks']
+                new_dataset_kwargs_dict = dict(chunks=new_dataset_kwargs_dict['sparse_chunks'], **new_dataset_kwargs_dict)
+        else:
+            write_attribute(f, f"{key}/{sub_k}", sub_v, new_dataset_kwargs_dict)
 
 
 @report_write_key_on_error

--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -86,18 +86,16 @@ def write_mapping(f, key, value: Mapping, dataset_kwargs=MappingProxyType({})):
             )
         is_sparse = isinstance(sub_v, sparse.spmatrix)
         new_dataset_kwargs_dict = deepcopy(dataset_kwargs.copy())
-        if 'chunks' in dataset_kwargs:
-            if dataset_kwargs['chunks'] is not None and not is_sparse:
-                if 'chunks' in dataset_kwargs:
-                    del new_dataset_kwargs_dict['sparse_chunks']
-                new_dataset_kwargs_dict = dict(chunks=new_dataset_kwargs_dict['chunks'], **new_dataset_kwargs_dict)
-        elif 'sparse_chunks' in dataset_kwargs:
+        # Delete sparse_chunks key if not sparse and chunks key if it is.
+        if not is_sparse and 'sparse_chunks' in dataset_kwargs: 
+            del new_dataset_kwargs_dict['sparse_chunks']
+        if is_sparse and 'chunks' in dataset_kwargs: 
+            del new_dataset_kwargs_dict['chunks']
+        # If it is sparse and there is a sparse_chunks key, make it the new chunks key
+        if 'sparse_chunks' in dataset_kwargs:
             if dataset_kwargs['sparse_chunks'] is not None and is_sparse:
-                if 'sparse_chunks' in dataset_kwargs:
-                    del new_dataset_kwargs_dict['chunks']
                 new_dataset_kwargs_dict = dict(chunks=new_dataset_kwargs_dict['sparse_chunks'], **new_dataset_kwargs_dict)
-        else:
-            write_attribute(f, f"{key}/{sub_k}", sub_v, new_dataset_kwargs_dict)
+        write_attribute(f, f"{key}/{sub_k}", sub_v, new_dataset_kwargs_dict)
 
 
 @report_write_key_on_error

--- a/anndata/_io/zarr.py
+++ b/anndata/_io/zarr.py
@@ -86,15 +86,19 @@ def write_mapping(f, key, value: Mapping, dataset_kwargs=MappingProxyType({})):
             )
         is_sparse = isinstance(sub_v, sparse.spmatrix)
         new_dataset_kwargs_dict = deepcopy(dataset_kwargs.copy())
-        # Delete sparse_chunks key if not sparse and chunks key if it is.
-        if not is_sparse and 'sparse_chunks' in dataset_kwargs: 
-            del new_dataset_kwargs_dict['sparse_chunks']
-        if is_sparse and 'chunks' in dataset_kwargs: 
-            del new_dataset_kwargs_dict['chunks']
-        # If it is sparse and there is a sparse_chunks key, make it the new chunks key
-        if 'sparse_chunks' in dataset_kwargs:
-            if dataset_kwargs['sparse_chunks'] is not None and is_sparse:
-                new_dataset_kwargs_dict = dict(chunks=new_dataset_kwargs_dict['sparse_chunks'], **new_dataset_kwargs_dict)
+        # Pop sparse chunks and chunks keys if possible.
+        sparse_chunks = None
+        chunks = None
+        if 'sparse_chunks' in new_dataset_kwargs_dict: 
+            sparse_chunks = new_dataset_kwargs_dict.pop('sparse_chunks')
+        if 'chunks' in new_dataset_kwargs_dict: 
+            chunks = new_dataset_kwargs_dict.pop('chunks')
+        # If it is sparse and there is a sparse_chunks key, make it the new chunks key,
+        # and similarly for dense matrices and chunks key
+        if sparse_chunks is not None and is_sparse:
+            new_dataset_kwargs_dict = dict(chunks=sparse_chunks, **new_dataset_kwargs_dict)
+        if chunks is not None and not is_sparse:
+            new_dataset_kwargs_dict = dict(chunks=chunks, **new_dataset_kwargs_dict)
         write_attribute(f, f"{key}/{sub_k}", sub_v, new_dataset_kwargs_dict)
 
 

--- a/anndata/tests/test_readwrite.py
+++ b/anndata/tests/test_readwrite.py
@@ -646,6 +646,21 @@ def test_zarr_chunk_X_sparse(tmp_path):
     from_zarr = ad.read_zarr(zarr_pth)
     assert_equal(from_zarr, adata)
 
+def test_zarr_chunk_layers(tmp_path):
+    import zarr
+
+    zarr_pth = Path(tmp_path) / "test.zarr"
+    adata = gen_adata((100, 100), X_type=csc_matrix)
+    adata.write_zarr(zarr_pth, sparse_chunks=(20,), chunks=(10, 10))
+
+    z = zarr.open(str(zarr_pth))  # As of v2.3.2 zarr won’t take a Path
+    assert z["layers"]['sparse']["data"].chunks == (20,)
+    assert z["layers"]['sparse']["indices"].chunks == (20,)
+    assert z["layers"]['sparse']["indptr"].chunks == (20,)
+    assert z["layers"]['array'].chunks == (10,10)
+    from_zarr = ad.read_zarr(zarr_pth)
+    assert_equal(from_zarr, adata)
+
 
 ################################
 # Round-tripping scanpy datasets


### PR DESCRIPTION
This PR begins to address https://github.com/theislab/anndata/issues/523 by simply passing through the `chunks` and `sparse_chunks` argument into the layers regardless of what the layers are.  In the future I could imagine a more complex API allowing you to do different chunking of different layers for different needs, but I think this is a good start that can leverage the existing API for a lot of nice use-cases.